### PR TITLE
git clone path changed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,8 +86,8 @@ rm -rf Elemental
 ### Clone the Alchemist repo
 ```
 export ALCHEMIST_PATH=(/desired/path/to/Alchemist/directory)
+git clone https://github.com/project-alchemist/Alchemist.git $ALCHEMIST_PATH
 cd $ALCHEMIST_PATH
-git clone https://github.com/project-alchemist/Alchemist.git
 ```
 
 ### Update configuration file


### PR DESCRIPTION
The instruction in the base repo creates the cloned directory inside ALCHEMIST_PATH, but the root of the cloned directory should be the ALCHEMIST_PATH for the build.sh to work properly.